### PR TITLE
Add a more complex example to aid in understanding correct usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 ProtobufJson
+Output.bin
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CXXFLAGS ?= -I/usr/local/include
 LDFLAGS ?= -L/usr/local/lib
+# To statically link, run `make` with `LDLIBS=/full/path/to/libprotobuf.a make`
 LDLIBS ?= -lprotobuf
 
 ProtobufJson: ProtobufJson.cc

--- a/README.md
+++ b/README.md
@@ -10,13 +10,59 @@ Once the dependency is installed this project can be built with an invocation
 of `make` on either OSX or Linux.
 
 ## Example usage
+
 Here's an invocation to convert JSON to protobuf.
 
-    ./ProtobufJson ToProto Example.proto Example '{"x": 5, "text": "Hello World"}' > Output.bin
+```bash
+./ProtobufJson ToProto Example.proto Example '{"x": 5, "text": "Hello World"}' > Output.bin
+```
 
 Here's an invocation to convert protobuf to JSON.
 
-    ./ProtobufJson  ToJson Example.proto Example < Output.bin
+```bash
+./ProtobufJson  ToJson Example.proto Example < Output.bin
+```
+
+Note that the reference to the `.proto` file must be provided relative to the proto search paths specified with `--proto_path` (by default, the proto search path is the current directory). Attempts to reference a `.proto` file by a full path (such as `${HOME}/path/to/example.proto`) will fail. Instead, specify `--proto_path=${HOME}/path/to` and then specify `example.proto`, or specify `--proto_path=${HOME}/path` and then specify `to/example.proto`.
+
+For example, from within this project directory, run:
+
+```bash
+./ProtobufJson ToProto \
+  --proto_path=exampleProtoSearchPath \
+  anotherSubdirectory/Example2.proto \
+  Example2 \
+  '{"message":{"y": 5, "name": "Hello ProtobufJson"}}' \
+  > Output.bin
+```
+
+The directory `exampleProtoSearchPath` will be used for locating `.proto` files, including `Example2.proto`. Then, when `Example2.proto` imports `anotherSubdirectory/Example3.proto` `ProtobufJson` will search for that path within all specified `--proto_path` directories.
+
+A full "round trip" looks like:
+
+```bash
+./ProtobufJson ToProto \
+  --proto_path=exampleProtoSearchPath \
+  anotherSubdirectory/Example2.proto \
+  Example2 \
+  '{"message":{"y": 5, "name": "Hello ProtobufJson"}}' | \
+  ./ProtobufJson ToJson \
+    --proto_path=exampleProtoSearchPath \
+    anotherSubdirectory/Example2.proto \
+    Example2
+```
+
+producing output:
+
+```json
+{
+  "message": {
+    "y": 5,
+    "name": "Hello ProtobufJson"
+  }
+}
+```
 
 ## Dependencies
- * [Protocol Buffers](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md)
+
+- [Protocol Buffers](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md)

--- a/exampleProtoSearchPath/anotherSubdirectory/Example2.proto
+++ b/exampleProtoSearchPath/anotherSubdirectory/Example2.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+import "anotherSubdirectory/Example3.proto";
+
+message Example2 {
+  Example3 message = 1;
+}

--- a/exampleProtoSearchPath/anotherSubdirectory/Example3.proto
+++ b/exampleProtoSearchPath/anotherSubdirectory/Example3.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+message Example3 {
+  int32 y = 1;
+  string name = 2;
+}


### PR DESCRIPTION
Hi, this is a fantastic utility. I got a little confused on how to use it, as initially I was providing `/full/path/to/some.proto` as an argument and got a very unhelpful `File not found` error. Turns out that error is from deep within the `protobuf` library and was caused by me not understanding how to properly setup `--proto_path` and then reference a `.proto` file that exists within one of the configured proto search paths.

I added a more complex protobuf schema which `import`s another schema along with a couple examples to hopefully clarify how to use this for future travelers.

Also, I added comments in the `Makefile` for those (like me) who want to statically link `libprotobuf` into the output `ProtobufJson` binary.